### PR TITLE
Roomを作る。firestoreのrulesにより、roomのmembersしかmessagesを見られなくする。

### DIFF
--- a/components/MessageItem.vue
+++ b/components/MessageItem.vue
@@ -8,7 +8,7 @@
       v-list-tile-sub-title.text--primary(v-html="formatNewLine(message.data.content)" )
     v-list-tile-action
       v-list-tile-action-text {{ message.data.timestamp | formatUNIXtime }}
-      v-btn(@click='deleteMessage') 削除
+      v-btn(v-if='message.data.uid === authedUser.uid' @click='deleteMessage') 削除
 </template>
 
 <script>

--- a/components/MessageList.vue
+++ b/components/MessageList.vue
@@ -21,6 +21,13 @@ export default {
   },
   computed: {
     ...mapState('messages', ['messages']),
+    ...mapState('rooms', ['selectedRoomID']),
+  },
+  watch: {
+    selectedRoomID: function() {
+      this.$store.dispatch('messages/stopListener')
+      this.$store.dispatch('messages/startListener')
+    },
   },
   mounted() {
     this.$store.dispatch('messages/startListener')

--- a/components/MessagePost.vue
+++ b/components/MessagePost.vue
@@ -25,8 +25,6 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
-
 export default {
   data() {
     return {
@@ -36,22 +34,11 @@ export default {
       rules: [v => v !== '' || 'メッセージは空欄不可です'],
     }
   },
-  computed: {
-    ...mapState({
-      user: state => state.auth.authedUser,
-    }),
-  },
   methods: {
     postMessage() {
       if (this.$refs.post.validate()) {
-        const now = new Date().getTime()
-        this.$store.dispatch('auth/readUntil', now)
-        this.$store.dispatch('messages/add', {
-          uid: this.user.uid,
-          timestamp: now,
-          displayName: this.user.displayName,
-          content: this.content,
-        })
+        this.$store.dispatch('auth/readUntil', new Date().getTime())
+        this.$store.dispatch('messages/add', this.content)
         this.$refs.post.reset()
         this.sheet = false
       }

--- a/components/MessagePost.vue
+++ b/components/MessagePost.vue
@@ -38,9 +38,9 @@ export default {
     postMessage() {
       if (this.$refs.post.validate()) {
         this.$store.dispatch('messages/add', this.content)
+        this.$store.dispatch('auth/readUntil', new Date().getTime())
         this.$refs.post.reset()
         this.sheet = false
-        this.$store.dispatch('auth/readUntil', new Date().getTime())
       }
     },
   },

--- a/components/MessagePost.vue
+++ b/components/MessagePost.vue
@@ -37,10 +37,10 @@ export default {
   methods: {
     postMessage() {
       if (this.$refs.post.validate()) {
-        this.$store.dispatch('auth/readUntil', new Date().getTime())
         this.$store.dispatch('messages/add', this.content)
         this.$refs.post.reset()
         this.sheet = false
+        this.$store.dispatch('auth/readUntil', new Date().getTime())
       }
     },
   },

--- a/components/TheSidebar.vue
+++ b/components/TheSidebar.vue
@@ -4,18 +4,24 @@
       v-list-tile(
         v-for="room in rooms"
         :key="room.id"
-        @click=""
+        @click="selectRoom(room.id)"
       )
         v-list-tile-content
           v-list-tile-title {{ room.name }}
+          span(v-if="room.id === selectedRoomID") 選択中
 </template>
 
 <script>
 import { mapState } from 'vuex'
 export default {
-  computed: mapState('rooms', ['rooms']),
+  computed: mapState('rooms', ['rooms', 'selectedRoomID']),
   mounted() {
     this.$store.dispatch('rooms/initRooms')
+  },
+  methods: {
+    selectRoom(roomID) {
+      this.$store.dispatch('rooms/selectRoom', roomID)
+    },
   },
 }
 </script>

--- a/components/TheSidebar.vue
+++ b/components/TheSidebar.vue
@@ -1,0 +1,21 @@
+<template lang="pug">
+  v-navigation-drawer
+    v-list
+      v-list-tile(
+        v-for="room in rooms"
+        :key="room.id"
+        @click=""
+      )
+        v-list-tile-content
+          v-list-tile-title {{ room.name }}
+</template>
+
+<script>
+import { mapState } from 'vuex'
+export default {
+  computed: mapState('rooms', ['rooms']),
+  mounted() {
+    this.$store.dispatch('rooms/initRooms')
+  },
+}
+</script>

--- a/components/TheSidebar.vue
+++ b/components/TheSidebar.vue
@@ -5,10 +5,11 @@
         v-for="room in rooms"
         :key="room.id"
         @click="selectRoom(room.id)"
+        ripple
+        :color="room.id === selectedRoomID ? 'blue' : 'black'"
       )
         v-list-tile-content
           v-list-tile-title {{ room.name }}
-          span(v-if="room.id === selectedRoomID") 選択中
 </template>
 
 <script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,9 +2,9 @@
   v-app
     TheNavbar
     v-content
-      v-container(fill-height)
-        nuxt(v-if="isAuthed")
-        SignIn(v-else)
+      nuxt(v-if="isAuthed")
+      v-container(v-else fill-height)
+        SignIn
 </template>
 
 <script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,17 +1,21 @@
 <template lang="pug">
-  v-layout(column)
-    MessageList.scroll-y(style="height: calc(90vh - 64px)")
-    MessagePost(style="height: 10vh")
+  v-layout
+    TheSidebar
+    v-layout(column)
+      MessageList.scroll-y(style="height: calc(90vh - 64px)")
+      MessagePost(style="height: 10vh")
 </template>
 
 <script>
 import MessageList from '~/components/MessageList'
 import MessagePost from '~/components/MessagePost'
+import TheSidebar from '~/components/TheSidebar'
 
 export default {
   components: {
     MessageList,
     MessagePost,
+    TheSidebar,
   },
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,21 +1,26 @@
 <template lang="pug">
   v-layout
     TheSidebar
-    v-layout(column)
+    v-layout(v-if="selectedRoomID" column)
       MessageList.scroll-y(style="height: calc(90vh - 64px)")
       MessagePost(style="height: 10vh")
+    v-card(v-else height="100vh" width="100vw")
+       v-layout(align-center justify-center  fill-height) roomを選択してください
 </template>
 
 <script>
 import MessageList from '~/components/MessageList'
 import MessagePost from '~/components/MessagePost'
 import TheSidebar from '~/components/TheSidebar'
-
+import { mapState } from 'vuex'
 export default {
   components: {
     MessageList,
     MessagePost,
     TheSidebar,
+  },
+  computed: {
+    ...mapState('rooms', ['selectedRoomID']),
   },
 }
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -1,12 +1,14 @@
 import Vuex from 'vuex'
 import auth from './modules/auth'
 import messages from './modules/messages'
+import rooms from './modules/rooms'
 
 const store = () =>
   new Vuex.Store({
     modules: {
       auth,
       messages,
+      rooms,
     },
   })
 

--- a/store/modules/messages.js
+++ b/store/modules/messages.js
@@ -56,7 +56,9 @@ export default {
         .onSnapshot(snapshot => {
           if (isFirstLoad) {
             isFirstLoad = false
-            commit('initialize')
+            if (snapshot.empty) {
+              return
+            }
             snapshot.forEach(doc => {
               pushMessage(doc)
             })
@@ -81,8 +83,9 @@ export default {
           }
         })
     },
-    stopListener(context) {
+    stopListener({ commit }) {
       this.unsubscribe()
+      commit('initialize')
     },
     add({ commit, rootState }, content) {
       messagesRef.add({

--- a/store/modules/messages.js
+++ b/store/modules/messages.js
@@ -48,6 +48,7 @@ export default {
         })
       }
       this.unsubscribe = messagesRef
+        .where('roomID', '==', rootState.rooms.selectedRoom)
         .orderBy('timestamp', 'asc')
         .onSnapshot(snapshot => {
           if (isFirstLoad) {

--- a/store/modules/messages.js
+++ b/store/modules/messages.js
@@ -80,8 +80,14 @@ export default {
     stopListener(context) {
       this.unsubscribe()
     },
-    add(context, message) {
-      messagesRef.add(message)
+    add({ commit, rootState }, content) {
+      messagesRef.add({
+        uid: rootState.auth.authedUser.uid,
+        timestamp: new Date().getTime(),
+        displayName: rootState.auth.authedUser.displayName,
+        content: content,
+        roomID: rootState.rooms.selectedRoom,
+      })
     },
     delete(context, message) {
       messagesRef.doc(message.id).delete()

--- a/store/modules/messages.js
+++ b/store/modules/messages.js
@@ -12,6 +12,9 @@ export default {
     }
   },
   mutations: {
+    initialize(state) {
+      state.messages = []
+    },
     push(state, message) {
       state.messages.push(message)
     },
@@ -48,11 +51,12 @@ export default {
         })
       }
       this.unsubscribe = messagesRef
-        .where('roomID', '==', rootState.rooms.selectedRoom)
+        .where('roomID', '==', rootState.rooms.selectedRoomID)
         .orderBy('timestamp', 'asc')
         .onSnapshot(snapshot => {
           if (isFirstLoad) {
             isFirstLoad = false
+            commit('initialize')
             snapshot.forEach(doc => {
               pushMessage(doc)
             })
@@ -86,7 +90,7 @@ export default {
         timestamp: new Date().getTime(),
         displayName: rootState.auth.authedUser.displayName,
         content: content,
-        roomID: rootState.rooms.selectedRoom,
+        roomID: rootState.rooms.selectedRoomID,
       })
     },
     delete(context, message) {

--- a/store/modules/rooms.js
+++ b/store/modules/rooms.js
@@ -8,26 +8,26 @@ export default {
   state() {
     return {
       rooms: [],
-      selectedRoom: '7GgevlydJpzgema5UCJB',
+      selectedRoomID: '7GgevlydJpzgema5UCJB',
     }
   },
   mutations: {
-    initRooms(state) {
+    initialize(state) {
       state.rooms = []
     },
-    addRoom(state, roomID) {
+    push(state, roomID) {
       state.rooms.push(roomID)
     },
   },
   actions: {
     initRooms({ commit, rootState }) {
-      commit('initRooms')
+      commit('initialize')
       roomsRef
         .where('members', 'array-contains', rootState.auth.authedUser.uid)
         .get()
         .then(querySnapshot => {
           querySnapshot.forEach(doc => {
-            commit('addRoom', { ...doc.data(), id: doc.id })
+            commit('push', { ...doc.data(), id: doc.id })
           })
         })
     },

--- a/store/modules/rooms.js
+++ b/store/modules/rooms.js
@@ -8,7 +8,7 @@ export default {
   state() {
     return {
       rooms: [],
-      selectedRoomID: '7GgevlydJpzgema5UCJB',
+      selectedRoomID: '',
     }
   },
   mutations: {
@@ -30,7 +30,10 @@ export default {
         .get()
         .then(querySnapshot => {
           querySnapshot.forEach(doc => {
-            commit('push', { ...doc.data(), id: doc.id })
+            commit('push', {
+              ...doc.data(),
+              id: doc.id,
+            })
           })
         })
     },

--- a/store/modules/rooms.js
+++ b/store/modules/rooms.js
@@ -18,6 +18,9 @@ export default {
     push(state, roomID) {
       state.rooms.push(roomID)
     },
+    select(state, roomID) {
+      state.selectedRoomID = roomID
+    },
   },
   actions: {
     initRooms({ commit, rootState }) {
@@ -30,6 +33,9 @@ export default {
             commit('push', { ...doc.data(), id: doc.id })
           })
         })
+    },
+    selectRoom({ commit }, roomID) {
+      commit('select', roomID)
     },
   },
 }

--- a/store/modules/rooms.js
+++ b/store/modules/rooms.js
@@ -1,9 +1,35 @@
+import firebase from '~/plugins/firebase.js'
+const db = firebase.firestore()
+db.settings({ timestampsInSnapshots: true })
+const roomsRef = db.collection('rooms')
+
 export default {
   namespaced: true,
   state() {
     return {
-      rooms: ['7GgevlydJpzgema5UCJB'],
+      rooms: [],
       selectedRoom: '7GgevlydJpzgema5UCJB',
     }
+  },
+  mutations: {
+    initRooms(state) {
+      state.rooms = []
+    },
+    addRoom(state, roomID) {
+      state.rooms.push(roomID)
+    },
+  },
+  actions: {
+    initRooms({ commit, rootState }) {
+      commit('initRooms')
+      roomsRef
+        .where('members', 'array-contains', rootState.auth.authedUser.uid)
+        .get()
+        .then(querySnapshot => {
+          querySnapshot.forEach(doc => {
+            commit('addRoom', { ...doc.data(), id: doc.id })
+          })
+        })
+    },
   },
 }

--- a/store/modules/rooms.js
+++ b/store/modules/rooms.js
@@ -1,0 +1,9 @@
+export default {
+  namespaced: true,
+  state() {
+    return {
+      rooms: ['7GgevlydJpzgema5UCJB'],
+      selectedRoom: '7GgevlydJpzgema5UCJB',
+    }
+  },
+}


### PR DESCRIPTION
目的
- [ ] messageのセキュリティを強化する

実装
- サーバー側
- [ ] firestoreにroomsコレクションを新たに作る
- [ ] rulesを有効にし、メンバーしかmessageのクエリを叩けないようにする 

- クライアント側
- [ ] roomsを選択するサイドバーを作成
- [ ] 選択したroomに紐づいたmessagesのみを表示