### PR TITLE
[wip]通知の改善

### DIFF
--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -29,7 +29,6 @@ export default {
   data() {
     return {
       scrollTop: 0,
-      timer: null,
       isScrolledToEnd: true,
       messageListEl: null,
     }
@@ -49,14 +48,12 @@ export default {
     this.messageListEl.removeEventListner('scroll', this.handleScroll)
   },
   methods: {
-    handleScroll() {
-      if (this.timer === null) {
-        this.timer = setTimeout(() => {
-          this.scrollTop = this.messageListEl.scrollTop
-          clearTimeout(this.timer)
-          this.timer = null
-        }, 100)
-      }
+    sleep(msec) {
+      return new Promise(resolve => setTimeout(resolve, msec))
+    },
+    async handleScroll() {
+      await this.sleep(1000)
+      this.scrollTop = this.messageListEl.scrollTop
     },
     scrollToEnd() {
       const el = this.messageListEl

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -43,12 +43,9 @@ export default {
       this.$store.dispatch('messages/startListener')
     },
     scrollTop: function() {
-      this.isScrolledToEnd = this.messageListEl
-        ? this.messageListEl.scrollHeight -
-            this.messageListEl.offsetHeight -
-            this.scrollTop ===
-          0
-        : false
+      const el = this.messageListEl
+      const scrollBottom = el.scrollHeight - el.offsetHeight - this.scrollTop
+      this.isScrolledToEnd = el ? scrollBottom === 0 : false
     },
   },
   mounted() {

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -1,6 +1,7 @@
 <template lang="pug">
   v-layout(column)
     v-btn.scroll-btn(
+      v-show="!isScrolledToEnd"
       absolute
       fab
       small
@@ -10,7 +11,7 @@
       v-icon(dark) keyboard_arrow_down
     MessageList.scroll-y(
       @new-message="scrollToEnd"
-      ref="messageContainer"
+      ref="messageList"
       style="height: calc(90vh - 64px)"
     )
     MessagePost(style="height: 10vh")
@@ -27,6 +28,9 @@ export default {
   },
   data() {
     return {
+      scrollTop: 0,
+      timer: null,
+      isScrolledToEnd: true,
       messageListEl: null,
     }
   },
@@ -38,17 +42,37 @@ export default {
       this.$store.dispatch('messages/stopListener')
       this.$store.dispatch('messages/startListener')
     },
+    scrollTop: function() {
+      this.isScrolledToEnd = this.messageListEl
+        ? this.messageListEl.scrollHeight -
+            this.messageListEl.offsetHeight -
+            this.scrollTop ===
+          0
+        : false
+    },
   },
   mounted() {
-    this.messageListEl = this.$refs.messageContainer.$el
+    this.messageListEl = this.$refs.messageList.$el
     this.$store.dispatch('messages/startListener')
+    this.messageListEl.addEventListener('scroll', this.handleScroll)
   },
   beforeDestroy() {
+    this.messageListEl.removeEventListner('scroll', this.handleScroll)
     this.$store.dispatch('messages/stopListener')
   },
   methods: {
+    handleScroll() {
+      if (this.timer === null) {
+        this.timer = setTimeout(() => {
+          this.scrollTop = this.messageListEl.scrollTop
+          clearTimeout(this.timer)
+          this.timer = null
+        }, 100)
+      }
+    },
     scrollToEnd() {
-      this.messageListEl.scrollTop = this.messageListEl.scrollHeight
+      const el = this.messageListEl
+      el.scrollTop = el.scrollHeight
     },
   },
 }

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -10,7 +10,7 @@
     )
       v-icon(dark) keyboard_arrow_down
     MessageList.scroll-y(
-      @new-message="scrollToEnd"
+      @new-message="newMessage"
       ref="messageList"
       style="height: calc(90vh - 64px)"
     )
@@ -68,6 +68,11 @@ export default {
     scrollToEnd() {
       const el = this.messageListEl
       el.scrollTop = el.scrollHeight
+    },
+    newMessage() {
+      if (this.isScrolledToEnd !== false) {
+        this.scrollToEnd()
+      }
     },
   },
 }

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -60,7 +60,7 @@ export default {
       return new Promise(resolve => setTimeout(resolve, msec))
     },
     async handleScroll() {
-      await this.sleep(1000)
+      await this.sleep(100)
       this.scrollTop = this.messageListEl.scrollTop
     },
     scrollToEnd() {

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   v-layout(column)
     v-btn.scroll-btn(
-      v-show="!isScrolledToEnd"
+      v-show="isScrolledToEnd === false"
       absolute
       fab
       small
@@ -29,7 +29,7 @@ export default {
   data() {
     return {
       scrollTop: 0,
-      isScrolledToEnd: true,
+      isScrolledToEnd: null,
       messageListEl: null,
     }
   },
@@ -38,6 +38,14 @@ export default {
       const el = this.messageListEl
       const scrollBottom = el.scrollHeight - el.offsetHeight - this.scrollTop
       this.isScrolledToEnd = el ? scrollBottom === 0 : false
+    },
+    isScrolledToEnd: async function() {
+      if (this.isScrolledToEnd) {
+        await this.sleep(3000)
+        if (this.isScrolledToEnd) {
+          this.$store.dispatch('auth/readUntil', new Date().getTime())
+        }
+      }
     },
   },
   mounted() {

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -77,6 +77,7 @@ export default {
     },
     newMessage() {
       if (this.isScrolledToEnd !== false) {
+        this.isScrolledToEnd = false
         this.scrollToEnd()
       }
     },

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -43,7 +43,7 @@ export default {
       if (this.isScrolledToEnd) {
         await this.sleep(3000)
         if (this.isScrolledToEnd) {
-          this.$store.dispatch('auth/readUntil', new Date().getTime())
+          this.$store.dispatch('notifications/checked')
         }
       }
     },

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -33,7 +33,13 @@ export default {
       messageListEl: null,
     }
   },
+  computed: {
+    ...mapState('rooms', ['selectedRoomID']),
+  },
   watch: {
+    selectedRoomID: function() {
+      this.isScrolledToEnd = null
+    },
     scrollTop: function() {
       // スクロール位置を監視し、最下部であればthis.isScrolledToEndをtrue
       const el = this.messageListEl

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -34,14 +34,7 @@ export default {
       messageListEl: null,
     }
   },
-  computed: {
-    ...mapState('rooms', ['selectedRoomID']),
-  },
   watch: {
-    selectedRoomID: function() {
-      this.$store.dispatch('messages/stopListener')
-      this.$store.dispatch('messages/startListener')
-    },
     scrollTop: function() {
       const el = this.messageListEl
       const scrollBottom = el.scrollHeight - el.offsetHeight - this.scrollTop
@@ -50,12 +43,10 @@ export default {
   },
   mounted() {
     this.messageListEl = this.$refs.messageList.$el
-    this.$store.dispatch('messages/startListener')
     this.messageListEl.addEventListener('scroll', this.handleScroll)
   },
   beforeDestroy() {
     this.messageListEl.removeEventListner('scroll', this.handleScroll)
-    this.$store.dispatch('messages/stopListener')
   },
   methods: {
     handleScroll() {

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -41,7 +41,7 @@ export default {
     },
     isScrolledToEnd: async function() {
       if (this.isScrolledToEnd) {
-        await this.sleep(3000)
+        await this.sleep(2000)
         if (this.isScrolledToEnd) {
           this.$store.dispatch('notifications/checked')
         }
@@ -60,7 +60,7 @@ export default {
       return new Promise(resolve => setTimeout(resolve, msec))
     },
     async handleScroll() {
-      await this.sleep(100)
+      await this.sleep(50)
       this.scrollTop = this.messageListEl.scrollTop
     },
     scrollToEnd() {

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -1,0 +1,62 @@
+<template lang="pug">
+  v-layout(column)
+    v-btn.scroll-btn(
+      absolute
+      fab
+      small
+      color="primary"
+      @click='scrollToEnd'
+    )
+      v-icon(dark) keyboard_arrow_down
+    MessageList.scroll-y(
+      @new-message="scrollToEnd"
+      ref="messageContainer"
+      style="height: calc(90vh - 64px)"
+    )
+    MessagePost(style="height: 10vh")
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import MessageList from '~/components/MessageList'
+import MessagePost from '~/components/MessagePost'
+export default {
+  components: {
+    MessageList,
+    MessagePost,
+  },
+  data() {
+    return {
+      messageListEl: null,
+    }
+  },
+  computed: {
+    ...mapState('rooms', ['selectedRoomID']),
+  },
+  watch: {
+    selectedRoomID: function() {
+      this.$store.dispatch('messages/stopListener')
+      this.$store.dispatch('messages/startListener')
+    },
+  },
+  mounted() {
+    this.messageListEl = this.$refs.messageContainer.$el
+    this.$store.dispatch('messages/startListener')
+  },
+  beforeDestroy() {
+    this.$store.dispatch('messages/stopListener')
+  },
+  methods: {
+    scrollToEnd() {
+      this.messageListEl.scrollTop = this.messageListEl.scrollHeight
+    },
+  },
+}
+</script>
+
+<style scoped lang="sass">
+  .scroll-btn
+    top: 0pt
+    right: 0pt
+    margin: 20pt
+</style>

--- a/components/MessageContainer.vue
+++ b/components/MessageContainer.vue
@@ -35,11 +35,13 @@ export default {
   },
   watch: {
     scrollTop: function() {
+      // スクロール位置を監視し、最下部であればthis.isScrolledToEndをtrue
       const el = this.messageListEl
       const scrollBottom = el.scrollHeight - el.offsetHeight - this.scrollTop
       this.isScrolledToEnd = el ? scrollBottom === 0 : false
     },
     isScrolledToEnd: async function() {
+      // スクロール位置が最下部を2秒キープしたとき、既読をつける
       if (this.isScrolledToEnd) {
         await this.sleep(2000)
         if (this.isScrolledToEnd) {

--- a/components/MessageItem.vue
+++ b/components/MessageItem.vue
@@ -26,8 +26,10 @@ export default {
   },
   computed: {
     ...mapState('auth', ['authedUser']),
+    ...mapState('notifications', ['notifications']),
     isNew() {
-      return this.message.data.timestamp > this.authedUser.readUntil
+      const data = this.message.data
+      return data.timestamp > this.notifications[data.roomID].checkedAt
     },
   },
   methods: {

--- a/components/MessageItem.vue
+++ b/components/MessageItem.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  v-list-tile(@click='readUntil')
+  v-list-tile
     v-list-tile-content
       v-badge(v-model="isNew" color="red lighten-3")
         span.caption(slot="badge") new
@@ -31,9 +31,6 @@ export default {
     },
   },
   methods: {
-    readUntil() {
-      this.$store.dispatch('auth/readUntil', this.message.data.timestamp)
-    },
     deleteMessage() {
       this.$store.dispatch('messages/delete', this.message)
     },

--- a/components/MessageList.vue
+++ b/components/MessageList.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  v-card
+  v-card.scroll-y
     v-list(two-line)
       div(
         v-for="(message, index) in messages"

--- a/components/MessageList.vue
+++ b/components/MessageList.vue
@@ -20,8 +20,8 @@ export default {
     MessageItem,
   },
   computed: {
-    ...mapState('rooms', ['selectedRoomID']),
     ...mapState('messages', ['messages']),
+    ...mapState('rooms', ['selectedRoomID']),
   },
   watch: {
     selectedRoomID: function() {

--- a/components/MessageList.vue
+++ b/components/MessageList.vue
@@ -1,7 +1,5 @@
 <template lang="pug">
-  .scroll-y(ref="messageListCard")
-    v-btn.scroll-btn(absolute fab small color="primary" @click='scrollToEnd')
-      v-icon(dark) keyboard_arrow_down
+  div
     v-list(two-line)
       div(
         v-for="(message, index) in messages"
@@ -23,22 +21,9 @@ export default {
   },
   computed: {
     ...mapState('messages', ['messages']),
-    ...mapState('rooms', ['selectedRoomID']),
-  },
-  watch: {
-    selectedRoomID: function() {
-      this.$store.dispatch('messages/stopListener')
-      this.$store.dispatch('messages/startListener')
-    },
-  },
-  mounted() {
-    this.$store.dispatch('messages/startListener')
   },
   updated() {
-    this.scrollToEnd()
-  },
-  destroyed() {
-    this.$store.dispatch('messages/stopListener')
+    this.$emit('new-message')
   },
   methods: {
     UNIXtimeToDate(UNIXtime) {
@@ -48,17 +33,6 @@ export default {
       const getDate = message => this.UNIXtimeToDate(message.data.timestamp)
       return getDate(currentMessage) !== getDate(prevMessage)
     },
-    scrollToEnd() {
-      const container = this.$refs.messageListCard
-      container.scrollTop = container.scrollHeight
-    },
   },
 }
 </script>
-
-<style scoped lang="sass">
-  .scroll-btn
-    top: 0pt
-    right: 0pt
-    margin: 20pt
-</style>

--- a/components/MessageList.vue
+++ b/components/MessageList.vue
@@ -29,11 +29,12 @@ export default {
     selectedRoomID: function() {
       this.$store.dispatch('messages/stopListener')
       this.$store.dispatch('messages/startListener')
-      this.scrollToEnd()
     },
   },
   mounted() {
     this.$store.dispatch('messages/startListener')
+  },
+  updated() {
     this.scrollToEnd()
   },
   destroyed() {

--- a/components/MessageList.vue
+++ b/components/MessageList.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
-  v-card.scroll-y
+  .scroll-y(ref="messageListCard")
+    v-btn.scroll-btn(absolute fab small color="primary" @click='scrollToEnd')
+      v-icon(dark) keyboard_arrow_down
     v-list(two-line)
       div(
         v-for="(message, index) in messages"
@@ -27,10 +29,12 @@ export default {
     selectedRoomID: function() {
       this.$store.dispatch('messages/stopListener')
       this.$store.dispatch('messages/startListener')
+      this.scrollToEnd()
     },
   },
   mounted() {
     this.$store.dispatch('messages/startListener')
+    this.scrollToEnd()
   },
   destroyed() {
     this.$store.dispatch('messages/stopListener')
@@ -43,9 +47,17 @@ export default {
       const getDate = message => this.UNIXtimeToDate(message.data.timestamp)
       return getDate(currentMessage) !== getDate(prevMessage)
     },
+    scrollToEnd() {
+      const container = this.$refs.messageListCard
+      container.scrollTop = container.scrollHeight
+    },
   },
 }
 </script>
 
 <style scoped lang="sass">
+  .scroll-btn
+    top: 0pt
+    right: 0pt
+    margin: 20pt
 </style>

--- a/components/MessageList.vue
+++ b/components/MessageList.vue
@@ -20,10 +20,23 @@ export default {
     MessageItem,
   },
   computed: {
+    ...mapState('rooms', ['selectedRoomID']),
     ...mapState('messages', ['messages']),
+  },
+  watch: {
+    selectedRoomID: function() {
+      this.$store.dispatch('messages/stopListener')
+      this.$store.dispatch('messages/startListener')
+    },
   },
   updated() {
     this.$emit('new-message')
+  },
+  mounted() {
+    this.$store.dispatch('messages/startListener')
+  },
+  beforeDestroy() {
+    this.$store.dispatch('messages/stopListener')
   },
   methods: {
     UNIXtimeToDate(UNIXtime) {

--- a/components/MessagePost.vue
+++ b/components/MessagePost.vue
@@ -37,8 +37,8 @@ export default {
   methods: {
     postMessage() {
       if (this.$refs.post.validate()) {
-        this.$store.dispatch('messages/add', this.content)
         this.$store.dispatch('notifications/checked')
+        this.$store.dispatch('messages/add', this.content)
         this.$refs.post.reset()
         this.sheet = false
       }

--- a/components/MessagePost.vue
+++ b/components/MessagePost.vue
@@ -38,7 +38,7 @@ export default {
     postMessage() {
       if (this.$refs.post.validate()) {
         this.$store.dispatch('messages/add', this.content)
-        this.$store.dispatch('auth/readUntil', new Date().getTime())
+        this.$store.dispatch('notifications/checked')
         this.$refs.post.reset()
         this.sheet = false
       }

--- a/components/MessagePost.vue
+++ b/components/MessagePost.vue
@@ -37,8 +37,8 @@ export default {
   methods: {
     postMessage() {
       if (this.$refs.post.validate()) {
-        this.$store.dispatch('notifications/checked')
         this.$store.dispatch('messages/add', this.content)
+        this.$store.dispatch('notifications/checked')
         this.$refs.post.reset()
         this.sheet = false
       }

--- a/components/TheSidebar.vue
+++ b/components/TheSidebar.vue
@@ -11,7 +11,7 @@
         v-list-tile-content
           v-badge.room-badge(left)
             span.caption(
-              v-if="notifications[room.id]"
+              v-if="notifications[room.id] && notifications[room.id].number > 0"
               slot="badge"
               ) {{ notifications[room.id].number }}
             v-list-tile-title {{ room.name }}

--- a/components/TheSidebar.vue
+++ b/components/TheSidebar.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   v-navigation-drawer
     v-list
-      v-list-tile(
+      v-list-tile.room-tile(
         v-for="room in rooms"
         :key="room.id"
         @click="selectRoom(room.id)"
@@ -9,13 +9,21 @@
         :color="room.id === selectedRoomID ? 'blue' : 'black'"
       )
         v-list-tile-content
-          v-list-tile-title {{ room.name }}
+          v-badge.room-badge(left)
+            span.caption(
+              v-if="notifications[room.id]"
+              slot="badge"
+              ) {{ notifications[room.id].number }}
+            v-list-tile-title {{ room.name }}
 </template>
 
 <script>
 import { mapState } from 'vuex'
 export default {
-  computed: mapState('rooms', ['rooms', 'selectedRoomID']),
+  computed: {
+    ...mapState('rooms', ['rooms', 'selectedRoomID']),
+    ...mapState('notifications', ['notifications']),
+  },
   mounted() {
     this.$store.dispatch('rooms/initRooms')
     this.$store.dispatch('notifications/startListener')
@@ -30,3 +38,8 @@ export default {
   },
 }
 </script>
+
+<style scoped lang="sass">
+  .room-badge
+    margin-left: 18pt
+</style>

--- a/components/TheSidebar.vue
+++ b/components/TheSidebar.vue
@@ -18,6 +18,10 @@ export default {
   computed: mapState('rooms', ['rooms', 'selectedRoomID']),
   mounted() {
     this.$store.dispatch('rooms/initRooms')
+    this.$store.dispatch('notifications/startListener')
+  },
+  beforeDestroy() {
+    this.$store.dispatch('notifications/stopListener')
   },
   methods: {
     selectRoom(roomID) {

--- a/firebase.json
+++ b/firebase.json
@@ -2,7 +2,8 @@
   "functions": {
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"
-    ]
+    ],
+    "source": "functions"
   },
   "hosting": {
     "public": "dist",

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,6 @@
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
-admin.initializeApp(functions.config().firebase)
+admin.initializeApp()
 const db = admin.firestore()
 db.settings({ timestampsInSnapshots: true })
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -8,17 +8,22 @@ exports.createMessage = functions.firestore
   .document('messages/{messageId}')
   .onCreate(async event => {
     const roomID = event.data().roomID
-    const notificationsRef = db.collection('notifications')
-    const notificationsSnap = await notificationsRef
-      .where('roomID', '==', roomID)
-      .get()
+    const notifsRef = db.collection('notifications')
+    const notifsSnap = await notifsRef.where('roomID', '==', roomID).get()
+    const roomRef = db.doc(`rooms/${roomID}`)
+    const roomSnap = await roomRef.get()
+    const roomName = roomSnap.data().name
+    const auther = event.data().displayName
+    const msgContent = event.data().content
+    const notifContent = `[${auther}@${roomName}]${msgContent}`
 
-    notificationsSnap.forEach(notification => {
+    notifsSnap.forEach(notification => {
       notification.ref.set(
         {
           number: notification.data().number + 1,
           latestMessageID: event.id,
           notified: false,
+          content: notifContent,
         },
         { merge: true }
       )

--- a/functions/index.js
+++ b/functions/index.js
@@ -18,9 +18,13 @@ exports.createMessage = functions.firestore
     const notifContent = `[${auther}@${roomName}] ${msgContent}`
 
     notifsSnap.forEach(notification => {
+      const number =
+        notification.data().userID === event.data().uid
+          ? notification.data().number
+          : notification.data().number + 1
       notification.ref.set(
         {
-          number: notification.data().number + 1,
+          number: number,
           latestMessageID: event.id,
           content: notifContent,
         },

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,8 +1,26 @@
 const functions = require('firebase-functions')
+const admin = require('firebase-admin')
+admin.initializeApp(functions.config().firebase)
+const db = admin.firestore()
+db.settings({ timestampsInSnapshots: true })
 
-// // Create and Deploy Your First Cloud Functions
-// // https://firebase.google.com/docs/functions/write-firebase-functions
-//
-// exports.helloWorld = functions.https.onRequest((request, response) => {
-//  response.send("Hello from Firebase!");
-// });
+exports.createMessage = functions.firestore
+  .document('messages/{messageId}')
+  .onCreate(async event => {
+    const roomID = event.data().roomID
+    const notificationsRef = db.collection('notifications')
+    const notificationsSnap = await notificationsRef
+      .where('roomID', '==', roomID)
+      .get()
+
+    notificationsSnap.forEach(notification => {
+      notification.ref.set(
+        {
+          number: notification.data().number + 1,
+          latestMessageID: event.id,
+          notified: false,
+        },
+        { merge: true }
+      )
+    })
+  })

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,7 +15,7 @@ exports.createMessage = functions.firestore
     const roomName = roomSnap.data().name
     const auther = event.data().displayName
     const msgContent = event.data().content
-    const notifContent = `[${auther}@${roomName}]${msgContent}`
+    const notifContent = `[${auther}@${roomName}] ${msgContent}`
 
     notifsSnap.forEach(notification => {
       notification.ref.set(

--- a/functions/index.js
+++ b/functions/index.js
@@ -22,7 +22,7 @@ exports.createMessage = functions.firestore
         {
           number: notification.data().number + 1,
           latestMessageID: event.id,
-          notified: false,
+          isNotified: false,
           content: notifContent,
         },
         { merge: true }

--- a/functions/index.js
+++ b/functions/index.js
@@ -22,7 +22,6 @@ exports.createMessage = functions.firestore
         {
           number: notification.data().number + 1,
           latestMessageID: event.id,
-          isNotified: false,
           content: notifContent,
         },
         { merge: true }

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,9 @@
 {
   "name": "functions",
   "description": "Cloud Functions for Firebase",
+  "engines": {
+    "node": "8"
+  },
   "scripts": {
     "lint": "eslint .",
     "serve": "firebase serve --only functions",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,22 +1,18 @@
 <template lang="pug">
   v-layout
     TheSidebar
-    v-layout(v-if="selectedRoomID" column)
-      MessageList(style="height: calc(90vh - 64px)")
-      MessagePost(style="height: 10vh")
+    MessageContainer(v-if="selectedRoomID")
     v-card(v-else height="100vh" width="100vw")
        v-layout(align-center justify-center  fill-height) roomを選択してください
 </template>
 
 <script>
-import MessageList from '~/components/MessageList'
-import MessagePost from '~/components/MessagePost'
+import MessageContainer from '~/components/MessageContainer'
 import TheSidebar from '~/components/TheSidebar'
 import { mapState } from 'vuex'
 export default {
   components: {
-    MessageList,
-    MessagePost,
+    MessageContainer,
     TheSidebar,
   },
   computed: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,7 +2,7 @@
   v-layout
     TheSidebar
     v-layout(v-if="selectedRoomID" column)
-      MessageList.scroll-y(style="height: calc(90vh - 64px)")
+      MessageList(style="height: calc(90vh - 64px)")
       MessagePost(style="height: 10vh")
     v-card(v-else height="100vh" width="100vw")
        v-layout(align-center justify-center  fill-height) roomを選択してください

--- a/store/index.js
+++ b/store/index.js
@@ -2,6 +2,7 @@ import Vuex from 'vuex'
 import auth from './modules/auth'
 import messages from './modules/messages'
 import rooms from './modules/rooms'
+import notifications from './modules/notifications'
 
 const store = () =>
   new Vuex.Store({
@@ -9,6 +10,7 @@ const store = () =>
       auth,
       messages,
       rooms,
+      notifications,
     },
   })
 

--- a/store/modules/auth.js
+++ b/store/modules/auth.js
@@ -16,9 +16,6 @@ export default {
       state.authedUser = user
       state.isLoading = false
     },
-    readUntil(state, messageCreatedAt) {
-      state.authedUser.readUntil = messageCreatedAt
-    },
     loading(state) {
       state.isLoading = true
     },
@@ -38,7 +35,6 @@ export default {
         const userData = {
           displayName: authedUser.displayName,
           firstVisitAt: new Date().getTime(),
-          readUntil: 0,
         }
         doc.ref.set(userData)
         return userData

--- a/store/modules/auth.js
+++ b/store/modules/auth.js
@@ -33,13 +33,6 @@ export default {
       commit('loading')
       firebase.auth().signInWithRedirect(provider)
     },
-    readUntil({ commit, state }, messageCreatedAt) {
-      commit('readUntil', messageCreatedAt)
-      db.doc(`users/${state.authedUser.uid}`).set(
-        { readUntil: messageCreatedAt },
-        { merge: true }
-      )
-    },
     startListener({ commit }) {
       const createNewUser = (authedUser, doc) => {
         const userData = {

--- a/store/modules/messages.js
+++ b/store/modules/messages.js
@@ -26,7 +26,7 @@ export default {
     },
   },
   actions: {
-    startListener({ commit, state, rootState }) {
+    startListener({ commit, rootState }) {
       this.unsubscribe = messagesRef
         .where('roomID', '==', rootState.rooms.selectedRoomID)
         .orderBy('timestamp', 'asc')

--- a/store/modules/messages.js
+++ b/store/modules/messages.js
@@ -32,20 +32,6 @@ export default {
   actions: {
     startListener({ commit, state, rootState }) {
       commit('changeStatus', 'loading')
-      const isNewMessage = doc => {
-        return doc.data().timestamp > rootState.auth.authedUser.readUntil
-      }
-      const notifyNewMessage = () => {
-        if ('Notification' in window) {
-          const permission = Notification.permission
-          if (permission === 'denied' || permission === 'granted') {
-            // なんかする？
-          }
-          Notification.requestPermission().then(() => {
-            const notification = new Notification('新しいメッセージ')
-          })
-        }
-      }
       const pushMessage = doc => {
         commit('push', {
           id: doc.id,
@@ -60,18 +46,12 @@ export default {
         snapshot.forEach(doc => {
           pushMessage(doc)
         })
-        if (isNewMessage(snapshot.docs[snapshot.docs.length - 1])) {
-          notifyNewMessage()
-        }
         commit('changeStatus', 'firstLoad')
       }
       const readEventSnapshot = snapshot => {
         snapshot.docChanges().forEach(change => {
           if (change.type === 'added') {
             pushMessage(change.doc)
-            if (isNewMessage(change.doc)) {
-              notifyNewMessage()
-            }
           } else if (change.type === 'modified') {
             // 編集を検知した時の処理
           } else if (change.type === 'removed') {

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -32,18 +32,6 @@ export default {
           })
         }
       }
-      const createMessage = async (number, latestMessageID, roomID) => {
-        if (number > 1) {
-          return `新しい${number}件のメッセージ`
-        } else {
-          const messageSnap = await db.doc(`messages/${latestMessageID}`).get()
-          const roomSnap = await db.doc(`rooms/${roomID}`).get()
-          const roomName = roomSnap.data().name
-          const auther = messageSnap.data().displayName
-          const content = messageSnap.data().content
-          return `[${auther}@${roomName}]${content}`
-        }
-      }
       const notified = notificationId => {
         db.doc(`notifications/${notificationId}`).set(
           {
@@ -59,16 +47,15 @@ export default {
             if (change.type === 'added' || change.type === 'modified') {
               const data = change.doc.data()
               commit('change', data)
-              if (data.notified === false) {
-                createMessage(
-                  data.number,
-                  data.latestMessageID,
-                  data.roomID
-                ).then(message => {
-                  notify(message)
-                  notified(change.doc.id)
-                })
+              if (data.notified === true) {
+                return
               }
+              const message =
+                data.number > 1
+                  ? `新しい${data.number}件のメッセージ`
+                  : data.content
+              notify(message)
+              notified(change.doc.id)
             }
           })
         })

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -39,8 +39,9 @@ export default {
           snapshot.docChanges().forEach(change => {
             if (change.type === 'added' || change.type === 'modified') {
               const data = change.doc.data()
-              commit('change', data)
-              if (!isFirstLoad) {
+              const notificationsID = change.doc.id
+              commit('change', { ...data, notificationsID })
+              if (!isFirstLoad && data.number > 0) {
                 notify(data.content)
               }
             }
@@ -51,6 +52,20 @@ export default {
     stopListener({ commit }) {
       this.unsubscribe()
       commit('initialize')
+    },
+    checked({ state, rootState }) {
+      const selectedRoomID = rootState.rooms.selectedRoomID
+      const notifications = state.notifications
+      const notificationID = notifications[selectedRoomID].notificationsID
+      notificationsRef.doc(notificationID).set(
+        {
+          checkedAt: new Date().getTime(),
+          number: 0,
+        },
+        {
+          merge: true,
+        }
+      )
     },
   },
 }

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -16,10 +16,7 @@ export default {
       state.notifications = {}
     },
     change(state, payload) {
-      state.notifications[payload.roomID] = {
-        number: payload.number,
-        latestMessageID: payload.latestMessageID,
-      }
+      state.notifications[payload.roomID] = payload
     },
   },
   actions: {
@@ -29,12 +26,7 @@ export default {
         .onSnapshot(snapshot => {
           snapshot.docChanges().forEach(change => {
             if (change.type === 'added' || change.type === 'modified') {
-              const x = change.doc.data()
-              commit('change', {
-                roomID: x.roomID,
-                number: x.number,
-                latestMessageID: x.latestMessageID,
-              })
+              commit('change', change.doc.data())
             }
           })
         })

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -16,7 +16,10 @@ export default {
       state.notifications = {}
     },
     change(state, payload) {
-      state.notifications[payload.roomID] = payload
+      state.notifications = {
+        ...state.notifications,
+        [payload.roomID]: payload,
+      }
     },
   },
   actions: {

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -1,0 +1,47 @@
+import firebase from '~/plugins/firebase.js'
+const db = firebase.firestore()
+db.settings({ timestampsInSnapshots: true })
+const notificationsRef = db.collection('notifications')
+
+export default {
+  namespaced: true,
+  unsubscribe: null,
+  state() {
+    return {
+      notifications: {},
+    }
+  },
+  mutations: {
+    initialize(state) {
+      state.notifications = {}
+    },
+    change(state, payload) {
+      state.notifications[payload.roomID] = {
+        number: payload.number,
+        latestMessageID: payload.latestMessageID,
+      }
+    },
+  },
+  actions: {
+    startListener({ commit, rootState }) {
+      this.unsubscribe = notificationsRef
+        .where('userID', '==', rootState.auth.authedUser.uid)
+        .onSnapshot(snapshot => {
+          snapshot.docChanges().forEach(change => {
+            if (change.type === 'added' || change.type === 'modified') {
+              const x = change.doc.data()
+              commit('change', {
+                roomID: x.roomID,
+                number: x.number,
+                latestMessageID: x.latestMessageID,
+              })
+            }
+          })
+        })
+    },
+    stopListener({ commit }) {
+      this.unsubscribe()
+      commit('initialize')
+    },
+  },
+}

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -39,8 +39,8 @@ export default {
           snapshot.docChanges().forEach(change => {
             if (change.type === 'added' || change.type === 'modified') {
               const data = change.doc.data()
-              const notificationsID = change.doc.id
-              commit('change', { ...data, notificationsID })
+              const notificationID = change.doc.id
+              commit('change', { ...data, notificationID })
               if (!isFirstLoad && data.number > 0) {
                 notify(data.content)
               }
@@ -56,7 +56,7 @@ export default {
     checked({ state, rootState }) {
       const selectedRoomID = rootState.rooms.selectedRoomID
       const notifications = state.notifications
-      const notificationID = notifications[selectedRoomID].notificationsID
+      const notificationID = notifications[selectedRoomID].notificationID
       notificationsRef.doc(notificationID).set(
         {
           checkedAt: new Date().getTime(),

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -21,12 +21,31 @@ export default {
   },
   actions: {
     startListener({ commit, rootState }) {
+      const notify = (number, latestMessageContent) => {
+        if ('Notification' in window) {
+          const permission = Notification.permission
+          if (permission === 'denied' || permission === 'granted') {
+            // なんかする？
+          }
+          Notification.requestPermission().then(() => {
+            const message =
+              number > 1
+                ? `新しい${number}件のメッセージ`
+                : latestMessageContent
+            const notification = new Notification(message)
+          })
+        }
+      }
       this.unsubscribe = notificationsRef
         .where('userID', '==', rootState.auth.authedUser.uid)
         .onSnapshot(snapshot => {
           snapshot.docChanges().forEach(change => {
             if (change.type === 'added' || change.type === 'modified') {
-              commit('change', change.doc.data())
+              const data = change.doc.data()
+              commit('change', data)
+              if (data.notified === false) {
+                notify(data.number, 'ここにメッセージ内容を入れる')
+              }
             }
           })
         })

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -40,6 +40,7 @@ export default {
           { merge: true }
         )
       }
+      let isFirstLoad = true
       this.unsubscribe = notificationsRef
         .where('userID', '==', rootState.auth.authedUser.uid)
         .onSnapshot(snapshot => {
@@ -47,17 +48,20 @@ export default {
             if (change.type === 'added' || change.type === 'modified') {
               const data = change.doc.data()
               commit('change', data)
-              if (data.notified === true) {
-                return
+              if (!isFirstLoad) {
+                if (data.notified === true) {
+                  return
+                }
+                const message =
+                  data.number > 1
+                    ? `新しい${data.number}件のメッセージ`
+                    : data.content
+                notify(message)
               }
-              const message =
-                data.number > 1
-                  ? `新しい${data.number}件のメッセージ`
-                  : data.content
-              notify(message)
               notified(change.doc.id)
             }
           })
+          isFirstLoad = false
         })
     },
     stopListener({ commit }) {

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -48,7 +48,7 @@ export default {
             if (change.type === 'added' || change.type === 'modified') {
               const data = change.doc.data()
               commit('change', data)
-              if (!isFirstLoad && data.isNotified) {
+              if (!isFirstLoad && !data.isNotified) {
                 notify(data.content)
               }
               notified(change.doc.id)

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -32,14 +32,6 @@ export default {
           })
         }
       }
-      const notified = notificationId => {
-        db.doc(`notifications/${notificationId}`).set(
-          {
-            notified: true,
-          },
-          { merge: true }
-        )
-      }
       let isFirstLoad = true
       this.unsubscribe = notificationsRef
         .where('userID', '==', rootState.auth.authedUser.uid)
@@ -48,10 +40,9 @@ export default {
             if (change.type === 'added' || change.type === 'modified') {
               const data = change.doc.data()
               commit('change', data)
-              if (!isFirstLoad && !data.isNotified) {
+              if (!isFirstLoad) {
                 notify(data.content)
               }
-              notified(change.doc.id)
             }
           })
           isFirstLoad = false

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -48,10 +48,7 @@ export default {
             if (change.type === 'added' || change.type === 'modified') {
               const data = change.doc.data()
               commit('change', data)
-              if (!isFirstLoad) {
-                if (data.notified === true) {
-                  return
-                }
+              if (!isFirstLoad && data.isNotified) {
                 notify(data.content)
               }
               notified(change.doc.id)

--- a/store/modules/notifications.js
+++ b/store/modules/notifications.js
@@ -52,11 +52,7 @@ export default {
                 if (data.notified === true) {
                   return
                 }
-                const message =
-                  data.number > 1
-                    ? `新しい${data.number}件のメッセージ`
-                    : data.content
-                notify(message)
+                notify(data.content)
               }
               notified(change.doc.id)
             }

--- a/store/modules/rooms.js
+++ b/store/modules/rooms.js
@@ -23,19 +23,17 @@ export default {
     },
   },
   actions: {
-    initRooms({ commit, rootState }) {
+    async initRooms({ commit, rootState }) {
       commit('initialize')
-      roomsRef
+      const roomsSnap = await roomsRef
         .where('members', 'array-contains', rootState.auth.authedUser.uid)
         .get()
-        .then(querySnapshot => {
-          querySnapshot.forEach(doc => {
-            commit('push', {
-              ...doc.data(),
-              id: doc.id,
-            })
-          })
+      roomsSnap.forEach(doc => {
+        commit('push', {
+          ...doc.data(),
+          id: doc.id,
         })
+      })
     },
     selectRoom({ commit }, roomID) {
       commit('select', roomID)


### PR DESCRIPTION
- 通知をもっとそれらしく出したい

- [x] 通知にルーム名とメッセージ内容を表示

- [x] 通知をルームごとに管理

- [x] 同じメッセージの通知を複数回発生させない

- [x] 既読が自動でつく

これまで通知はfirestore/messagesを見て判断していたが、notificationsのコレクションを新たに作成し、柔軟に対応できるようにした。副産物として、store/messagesの責務が減った